### PR TITLE
add DirectMap1G to meminfo

### DIFF
--- a/linux/meminfo.go
+++ b/linux/meminfo.go
@@ -53,6 +53,7 @@ type Meminfo struct {
 	Hugepagesize      uint64
 	DirectMap4k       uint64
 	DirectMap2M       uint64
+	DirectMap1G       uint64
 }
 
 var procMeminfo = "/proc/meminfo"
@@ -184,6 +185,8 @@ func ReadMeminfo() (meminfo Meminfo, err error) {
 			meminfo.DirectMap4k = val
 		case "DirectMap2M":
 			meminfo.DirectMap2M = val
+		case "DirectMap1G":
+			meminfo.DirectMap1G = val
 		default:
 			log.Printf("ignoring unknown meminfo field %s", name)
 		}


### PR DESCRIPTION
ISSUE:

```
2014/06/19 09:51:11 ignoring unknown meminfo field DirectMap1G
```

would like to add DirectMap1G to meminfo

```
# plu@plu-9: grep DirectMap /proc/meminfo 
DirectMap4k:      163988 kB
DirectMap2M:     7100416 kB
DirectMap1G:    26214400 kB
```
